### PR TITLE
add GitBucket version to assembly jar filename

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 organization := "io.github.gitbucket"
 name := "sbt-gitbucket-plugin"
-version := "1.2.0"
+version := "1.2.1-SNAPSHOT"
 sbtPlugin := true
 sbtVersion := "1.0.0"
 libraryDependencies ++= Seq(

--- a/src/main/scala/io/github/gitbucket/sbt/GitBucketPlugin.scala
+++ b/src/main/scala/io/github/gitbucket/sbt/GitBucketPlugin.scala
@@ -20,7 +20,8 @@ object GitBucketPlugin extends sbt.AutoPlugin {
       "javax.servlet" % "javax.servlet-api" % "3.1.0" % "provided"
     ),
     resolvers += Resolver.bintrayRepo("bkromhout", "maven"),
-    assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false, includeDependency = true)
+    assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false, includeDependency = true),
+    assemblyJarName in assembly := name.value + "-gitbucket_" + gitbucketVersion.value + "-" + version.value + ".jar"
   ) ++ SbtTwirl.projectSettings.filterNot(_.key.key == libraryDependencies.key)
 
 }


### PR DESCRIPTION
for online repository or other purpose, GitBucket version is important information.
so adding GitBucket version to assembly jar filename is better solution.